### PR TITLE
fix bug parser thread dead block when the mysql socket occurs some error

### DIFF
--- a/src/main/java/com/google/code/or/io/util/ActiveBufferedInputStream.java
+++ b/src/main/java/com/google/code/or/io/util/ActiveBufferedInputStream.java
@@ -97,6 +97,14 @@ public final class ActiveBufferedInputStream extends InputStream implements Runn
 			this.exception = e;
 		} catch(Exception e) {
 			LOGGER.error("failed to transfer data", e);
+		} finally {
+			if (!this.closed.get()) {
+				try {
+					close();
+				} catch (IOException e) {
+					LOGGER.error("failed to close is", e);
+				}
+			}
 		}
 	}
 	


### PR DESCRIPTION
the parser thread will block on the condition bufferNotEmpty when the socket occurs some error. I add a close invoke when the ActiveBufferedInputStream thread exit to awake the parser thread. So the parser thread will know the socket error and exit.
